### PR TITLE
[GAMES-1481] - move reset function outside of callback

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -445,13 +445,13 @@ Request.prototype.routeCall = function (method, params, reset, callback) {
     return;
   }
 
+  if (reset === true) $this.reset();
+
   this.client[method](params, function (err, data) {
     if (err) $this.events.error.apply($this, [method, err, params]);
 
     if ((data || {}).hasOwnProperty("ConsumedCapacity"))
       $this.ConsumedCapacity = data.ConsumedCapacity;
-
-    if (reset === true) $this.reset();
 
     callback.apply($this, [err, data]);
   });

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -392,9 +392,9 @@ Request.prototype.routeCall = function (method, params, reset, callback) {
   var $this = this;
   this.events.beforeRequest.apply(this, [method, params]);
 
-  if (this.return_explain) {
-    if (reset === true) $this.reset();
+  if (reset === true) $this.reset();
 
+  if (this.return_explain) {
     switch (method) {
       case "putItem":
       case "updateItem":
@@ -444,8 +444,6 @@ Request.prototype.routeCall = function (method, params, reset, callback) {
     callback.apply($this, [null, explain]);
     return;
   }
-
-  if (reset === true) $this.reset();
 
   this.client[method](params, function (err, data) {
     if (err) $this.events.error.apply($this, [method, err, params]);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.9",
+  "version": "2.0.8",
   "contributors": [
     "Adrian Praja <adrian@databank.ro> (https://awspilot.dev)",
     "Mark Whelan <mark.whelan@theathletic.com> (https://theathletic.com)"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0",
+  "version": "2.0.8",
   "contributors": [
     "Adrian Praja <adrian@databank.ro> (https://awspilot.dev)",
     "Mark Whelan <mark.whelan@theathletic.com> (https://theathletic.com)"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.8",
+  "version": "2.0.9",
   "contributors": [
     "Adrian Praja <adrian@databank.ro> (https://awspilot.dev)",
     "Mark Whelan <mark.whelan@theathletic.com> (https://theathletic.com)"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.8",
+  "version": "2.1.0",
   "contributors": [
     "Adrian Praja <adrian@databank.ro> (https://awspilot.dev)",
     "Mark Whelan <mark.whelan@theathletic.com> (https://theathletic.com)"


### PR DESCRIPTION
This fix solves an issue we were seeing when parallel queries were being made by various graphql field resolvers.

Please verify my tests in this attached PDF:
[GAMES-1481_testing.pdf](https://github.com/user-attachments/files/17645807/GAMES-1481_testing.pdf)

I believe this change to fix the most recent issue with the [apollo aws sdk v3 upgrade PR](https://github.com/TheAthletic/theathletic-apollo-express/pull/5806) which broke the onboarding flow.

Once this change is merged into this lib, we will need to update the library in apollo and verify the sdk upgrade changes in apollo.

Test Query:
```
query UserInfoQuery {
  user {
    id
    
    ... on Customer {
      onboarding_completed
      onboarding_skipped
    }
  }
}
```

The user id for this query is derived from the `Authorization: Bearer <ath_access_token>` which can be determined via a logged in session using the web client and then visiting the `/get-current-user` endpoint via the PHP api.

